### PR TITLE
make homebrew Cellar path dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ bash < <(curl -sL https://raw.github.com/mattreduce/oblique-fortunes/master/get)
 brew install fortune
 git clone https://github.com/mattreduce/oblique-fortunes.git
 cd oblique-fortunes
-cp oblique* /usr/local/Cellar/fortune/**/share/games/fortunes/
+cp oblique* $(brew --cellar)/fortune/**/share/games/fortunes/
 echo 'if command fortune >/dev/null; then fortune oblique; fi' >> ~/.bash_profile
 ```
 

--- a/get
+++ b/get
@@ -14,7 +14,7 @@ echo "Cloning oblique-fortunes ..."
 
 echo "Installing fortune files ..."
   successfully cd oblique-fortunes
-  successfully cp oblique* /usr/local/Cellar/fortune/**/share/games/fortunes/
+  successfully cp oblique* $(brew --cellar)/fortune/**/share/games/fortunes/
 
 echo "Adding fortune to ~/.bash_profile ..."
   echo "


### PR DESCRIPTION
The default path for the homebrew "Cellar" had changed from `/usr/local/Cellar` to `/opt/homebrew/Cellar` a while ago.

But instead of just updating the path I thought it might be better to use the output of `brew --cellar` to make it more flexible.